### PR TITLE
feat: 廃止予定の旧APIメソッドを削除

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -110,7 +110,7 @@ func TestUserRepository(t *testing.T) {
                 t.Fatal(err)
             }
 
-                    if len(users) != 2 {
+        if len(users) != 2 {
             t.Errorf("expected: 2, got: %d", len(users))
         }
         },
@@ -319,13 +319,7 @@ func (tf *TestFixture) GetTransaction() *sql.Tx
 func (tf *TestFixture) TearDownTest()
 ```
 
-**廃止予定のメソッド（互換性のため残存）**
-```go
-// 非推奨：RunTestWithSetupまたはRunTestを使用してください
-func (tf *TestFixture) ExecInTransaction(query string, args ...interface{})
-func (tf *TestFixture) QueryInTransaction(query string, args ...interface{}) *sql.Rows
-func (tf *TestFixture) QueryRowInTransaction(query string, args ...interface{}) *sql.Row
-```
+
 
 ## 🎯 使い方のベストプラクティス
 
@@ -364,7 +358,7 @@ fixture.RunTestWithCustomSetup(func(tx *sql.Tx) {
 | -------------------- | ------------------------------- | ------------------ |
 | フィクスチャ挿入     | `fixture.InsertTestData()` 必須 | 自動実行           |
 | トランザクション取得 | `fixture.GetTransaction()`      | 引数で直接受け取り |
-| SQL実行              | `fixture.ExecInTransaction()`   | `tx.Exec()`        |
+| SQL実行              | ヘルパーメソッド                | `tx.Exec()` 直接   |
 | エラーハンドリング   | ヘルパーメソッド内で自動        | 明示的制御         |
 | 可読性               | 冗長                            | 簡潔               |
 | 柔軟性               | 限定的                          | 高い               |
@@ -372,14 +366,14 @@ fixture.RunTestWithCustomSetup(func(tx *sql.Tx) {
 ### 💡 移行ガイド
 
 ```go
-// 旧API
+// 旧API (v0.1.x)
 fixture.RunTest(func() {
     fixture.ExecInTransaction("CREATE TABLE ...")
     fixture.InsertTestData()
     rows := fixture.QueryInTransaction("SELECT ...")
 })
 
-// 新API
+// 新API (v0.3.0+)
 fixture.RunTestWithSetup(
     func(tx *sql.Tx) {
         tx.Exec("CREATE TABLE ...")

--- a/README.md
+++ b/README.md
@@ -312,13 +312,6 @@ func (tf *TestFixture) GetTransaction() *sql.Tx
 func (tf *TestFixture) TearDownTest()
 ```
 
-**Deprecated Methods (kept for compatibility)**
-```go
-// Deprecated: Use RunTestWithSetup or RunTest instead
-func (tf *TestFixture) ExecInTransaction(query string, args ...interface{})
-func (tf *TestFixture) QueryInTransaction(query string, args ...interface{}) *sql.Rows
-func (tf *TestFixture) QueryRowInTransaction(query string, args ...interface{}) *sql.Row
-```
 
 ## 🎯 Best Practices
 
@@ -353,26 +346,26 @@ fixture.RunTestWithCustomSetup(func(tx *sql.Tx) {
 
 ### 🆚 Old vs New API Comparison
 
-| Feature            | Old API                             | New API          |
-| ------------------ | ----------------------------------- | ---------------- |
-| Fixture Insertion  | `fixture.InsertTestData()` required | Automatic        |
-| Transaction Access | `fixture.GetTransaction()`          | Direct parameter |
-| SQL Execution      | `fixture.ExecInTransaction()`       | `tx.Exec()`      |
-| Error Handling     | Automatic in helper methods         | Explicit control |
-| Readability        | Verbose                             | Concise          |
-| Flexibility        | Limited                             | High             |
+| Feature            | Old API                             | New API              |
+| ------------------ | ----------------------------------- | -------------------- |
+| Fixture Insertion  | `fixture.InsertTestData()` required | Automatic            |
+| Transaction Access | `fixture.GetTransaction()`          | Direct parameter     |
+| SQL Execution      | Helper methods                      | `tx.Exec()` directly |
+| Error Handling     | Automatic in helper methods         | Explicit control     |
+| Readability        | Verbose                             | Concise              |
+| Flexibility        | Limited                             | High                 |
 
 ### 💡 Migration Guide
 
 ```go
-// Old API
+// Old API (v0.1.x)
 fixture.RunTest(func() {
     fixture.ExecInTransaction("CREATE TABLE ...")
     fixture.InsertTestData()
     rows := fixture.QueryInTransaction("SELECT ...")
 })
 
-// New API
+// New API (v0.3.0+)
 fixture.RunTestWithSetup(
     func(tx *sql.Tx) {
         tx.Exec("CREATE TABLE ...")

--- a/testing.go
+++ b/testing.go
@@ -100,37 +100,6 @@ func (tf *TestFixture) InsertTestData() {
 	}
 }
 
-// ExecInTransaction はトランザクション内でSQLを実行する
-func (tf *TestFixture) ExecInTransaction(query string, args ...interface{}) {
-	tf.t.Helper()
-
-	executor := tf.getExecutor()
-	_, err := executor.Exec(query, args...)
-	if err != nil {
-		tf.t.Fatalf("failed to execute SQL: %v", err)
-	}
-}
-
-// QueryInTransaction はトランザクション内でクエリを実行する
-func (tf *TestFixture) QueryInTransaction(query string, args ...interface{}) *sql.Rows {
-	tf.t.Helper()
-
-	executor := tf.getExecutor()
-	rows, err := executor.Query(query, args...)
-	if err != nil {
-		tf.t.Fatalf("failed to execute query: %v", err)
-	}
-	return rows
-}
-
-// QueryRowInTransaction はトランザクション内で単一行クエリを実行する
-func (tf *TestFixture) QueryRowInTransaction(query string, args ...interface{}) *sql.Row {
-	tf.t.Helper()
-
-	executor := tf.getExecutor()
-	return executor.QueryRow(query, args...)
-}
-
 // HasTransaction はトランザクションが開始されているかを確認する
 func (tf *TestFixture) HasTransaction() bool {
 	return tf.tx != nil


### PR DESCRIPTION
## 概要

Issue #7で計画された廃止予定の旧APIメソッドを削除し、新しいAPIに完全移行しました。

## 削除したメソッド

- `ExecInTransaction()` - 非推奨：RunTestWithSetupまたはRunTestを使用
- `QueryInTransaction()` - 非推奨：RunTestWithSetupまたはRunTestを使用  
- `QueryRowInTransaction()` - 非推奨：RunTestWithSetupまたはRunTestを使用

## 変更内容

### testing.go
- 廃止予定の3つのメソッドを削除
- 新しいAPI (`RunTest`, `RunTestWithSetup`) は既に実装済み

### README.md / README.ja.md
- 廃止予定メソッドの記載を削除
- 新しいAPIの使用方法に更新

### example/
- 既に新しいAPIを使用するよう更新済み
- 変更不要であることを確認

## 移行後のAPI

```go
// 旧API（削除済み）
fixture.ExecInTransaction("INSERT INTO ...")
fixture.QueryInTransaction("SELECT ...")

// 新API（推奨）
fixture.RunTest(func(tx *sql.Tx) {
    tx.Exec("INSERT INTO ...")
    rows, _ := tx.Query("SELECT ...")
})
```

## テスト

- [x] example/ のテストが正常動作することを確認
- [x] 新しいAPIの動作確認完了

Closes #7