### PR TITLE
chore: Go 1.25.0に更新

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.24'
+        go-version: '1.25'
     
     - name: Cache Go modules
       uses: actions/cache@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: ubuntu-latest
         
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.25'
-    
+        go-version-file: go.mod
+
     - name: Cache Go modules
       uses: actions/cache@v4
       with:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Yuki-TU/yamlfix
 
-go 1.24
+go 1.25
 
 require (
 	github.com/mattn/go-sqlite3 v1.14.18


### PR DESCRIPTION
## 概要

Go 1.25.0がリリースされたため、プロジェクトのGoバージョンを更新しました。

## 変更内容

### go.mod
- Go バージョンを 1.24 → 1.25 に更新

### GitHub Actions
- `.github/workflows/test.yml` の `go-version` を '1.24' → '1.25' に更新

## テスト結果

✅ **全テスト正常動作確認済み**
- `go test -v ./...` - 全て PASS
- `go test -v ./example/...` - 全て PASS  
- 新バージョンでのコンパイル・実行に問題なし

## 依存関係

- 依存パッケージに変更なし
- `go mod tidy` 実行済み

## Go 1.25.0 の恩恵

新しいGoバージョンの性能向上やセキュリティ修正の恩恵を受けることができます。

Closes #9